### PR TITLE
Add Terraform S3/Lambda deployment with GitHub Actions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,33 @@
+name: Terraform Deploy
+
+on:
+  push:
+    branches: [ main ]
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: hashicorp/setup-terraform@v2
+        with:
+          terraform_version: 1.5.7
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v2
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE }}
+          aws-region: us-east-1
+
+      - name: Terraform Init
+        working-directory: terraform
+        run: terraform init
+
+      - name: Terraform Apply
+        working-directory: terraform
+        run: terraform apply -auto-approve

--- a/.github/workflows/destroy.yml
+++ b/.github/workflows/destroy.yml
@@ -1,0 +1,32 @@
+name: Terraform Destroy
+
+on:
+  workflow_dispatch:
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  destroy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: hashicorp/setup-terraform@v2
+        with:
+          terraform_version: 1.5.7
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v2
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE }}
+          aws-region: us-east-1
+
+      - name: Terraform Init
+        working-directory: terraform
+        run: terraform init
+
+      - name: Terraform Destroy
+        working-directory: terraform
+        run: terraform destroy -auto-approve

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+*.zip
+.terraform/
+terraform/lambda.zip

--- a/README.md
+++ b/README.md
@@ -1,1 +1,21 @@
 # openai-with-aws-test7
+
+This repository demonstrates how to provision AWS infrastructure using Terraform and GitHub Actions. It creates:
+
+- An S3 bucket called `ontoscale-create-with-openai-codex`.
+- A Lambda function exposed through API Gateway that writes a file into the bucket.
+
+Terraform state is stored in the S3 bucket `ontoscale-terraform-backend`.
+
+## GitHub Actions
+
+Two workflows are provided:
+
+- **Deploy** (`.github/workflows/deploy.yml`) – runs on merges to `main` and applies the Terraform configuration using the `AWS_ROLE` secret.
+- **Destroy** (`.github/workflows/destroy.yml`) – can be triggered manually to tear down all resources.
+
+## Usage
+
+1. Commit changes and merge to `main` to trigger deployment.
+2. Trigger the Destroy workflow manually from the Actions tab when you want to remove the infrastructure.
+

--- a/lambda/lambda_function.py
+++ b/lambda/lambda_function.py
@@ -1,0 +1,15 @@
+import json
+import boto3
+import os
+import time
+
+s3 = boto3.client('s3')
+BUCKET_NAME = os.environ.get('BUCKET_NAME')
+
+def lambda_handler(event, context):
+    key = f"file_{int(time.time())}.txt"
+    s3.put_object(Bucket=BUCKET_NAME, Key=key, Body=b"Created by Lambda")
+    return {
+        'statusCode': 200,
+        'body': json.dumps({'message': f'File {key} created'})
+    }

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,0 +1,97 @@
+terraform {
+  backend "s3" {
+    bucket = "ontoscale-terraform-backend"
+    key    = "state/terraform.tfstate"
+    region = "us-east-1"
+  }
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = "us-east-1"
+}
+
+resource "aws_s3_bucket" "bucket" {
+  bucket = "ontoscale-create-with-openai-codex"
+}
+
+resource "aws_iam_role" "lambda_role" {
+  name = "lambda_execution_role"
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Action = "sts:AssumeRole"
+      Effect = "Allow"
+      Principal = {
+        Service = "lambda.amazonaws.com"
+      }
+    }]
+  })
+}
+
+resource "aws_iam_policy_attachment" "lambda_basic" {
+  name       = "lambda_basic_execution"
+  roles      = [aws_iam_role.lambda_role.name]
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+}
+
+data "archive_file" "lambda_zip" {
+  type        = "zip"
+  source_dir  = "${path.module}/../lambda"
+  output_path = "${path.module}/lambda.zip"
+}
+
+resource "aws_lambda_function" "example" {
+  function_name = "create-file-lambda"
+  handler       = "lambda_function.lambda_handler"
+  runtime       = "python3.11"
+  role          = aws_iam_role.lambda_role.arn
+  filename      = data.archive_file.lambda_zip.output_path
+  source_code_hash = filebase64sha256(data.archive_file.lambda_zip.output_path)
+  environment {
+    variables = {
+      BUCKET_NAME = aws_s3_bucket.bucket.bucket
+    }
+  }
+}
+
+resource "aws_apigatewayv2_api" "api" {
+  name          = "lambda-api"
+  protocol_type = "HTTP"
+}
+
+resource "aws_apigatewayv2_integration" "lambda_integration" {
+  api_id             = aws_apigatewayv2_api.api.id
+  integration_type   = "AWS_PROXY"
+  integration_uri    = aws_lambda_function.example.invoke_arn
+  payload_format_version = "2.0"
+}
+
+resource "aws_apigatewayv2_route" "default" {
+  api_id    = aws_apigatewayv2_api.api.id
+  route_key = "$default"
+  target    = "integrations/${aws_apigatewayv2_integration.lambda_integration.id}"
+}
+
+resource "aws_apigatewayv2_stage" "default" {
+  api_id      = aws_apigatewayv2_api.api.id
+  name        = "$default"
+  auto_deploy = true
+}
+
+resource "aws_lambda_permission" "api_gw" {
+  statement_id  = "AllowAPIGatewayInvoke"
+  action        = "lambda:InvokeFunction"
+  function_name = aws_lambda_function.example.function_name
+  principal     = "apigateway.amazonaws.com"
+  source_arn    = "${aws_apigatewayv2_api.api.execution_arn}/*/*"
+}
+
+output "api_endpoint" {
+  value = aws_apigatewayv2_stage.default.invoke_url
+}


### PR DESCRIPTION
## Summary
- create Terraform configuration to provision S3 bucket, Lambda and API Gateway
- add GitHub Actions workflows to deploy on merge to `main` and to destroy via manual trigger
- include Lambda function that writes to the S3 bucket
- document usage in README
- add `.gitignore`

## Testing
- `terraform init -backend=false`
- `terraform validate`

------
https://chatgpt.com/codex/tasks/task_e_68769bf5265c8331b33bfceeae73a26d